### PR TITLE
Add gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,29 @@
+# General setting that applies Git's binary detection for file-types not specified below
+# Meaning, for 'text-guessed' files:
+# use normalization (convert crlf -> lf on commit, i.e. use `text` setting) 
+# & do unspecified diff behavior (if file content is recognized as text & filesize < core.bigFileThreshold, do text diff on file changes)
+* text=auto
+
+
+# Override with explicit specific settings for known and/or likely text files in our repo that should be normalized
+# where diff{=optional_pattern} means "do text diff {with specific text pattern} and -diff means "don't do text diffs".
+# Unspecified diff behavior is decribed above
+*.cer      text -diff
+*.cmd      text
+*.cs       text diff=csharp
+*.csproj   text
+*.css      text diff=css
+Dockerfile text
+*.json     text
+*.md       text diff=markdown
+*.msbuild  text
+*.pem      text -diff
+*.ps1      text
+*.sln      text
+*.yaml     text
+*.yml      text
+
+# Files that should be treated as binary ('binary' is a macro for '-text -diff', i.e. "don't normalize or do text diff on content")
+*.jpeg    binary
+*.pfx     binary
+*.png     binary


### PR DESCRIPTION
Ensure consistent use of LF line endings in repository

## Description
Add gitattributes file to specify file types in text/binary format

## Related Issue(s)
https://github.com/Altinn/team-core-private/issues/238

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
